### PR TITLE
Fix page styling config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[theme]
+backgroundColor = "#EEE8D6"
+textColor = "#767564"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,0 @@
-toml
-    [theme]
-    backgroundColor = "#EEE8D6"
-    textColor = "#767564"


### PR DESCRIPTION
Page styling is not loading because it is not inside ./.streamlit folder ([streamlit docs](https://docs.streamlit.io/develop/api-reference/configuration/config.toml)).