### PR TITLE
Setting environment variable overriding

### DIFF
--- a/guaxinim/core/guaxinim_bot.py
+++ b/guaxinim/core/guaxinim_bot.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from guaxinim.core.coffee_data import CoffeePreparationData
 
 # Load environment variables
-load_dotenv()
+load_dotenv(override=True)
 
 
 class GuaxinimBot:


### PR DESCRIPTION
In the first time I executed the application, I forgot to replace the placeholder API key (from env.example model file) inside .env file, so the application kept loading `YOUR_API_KEY` as `OPENAI_API_KEY`, just as if it was my OpenAI key. I decided then to set `override=True` in `load_dotenv` call, so nobody else gets stuck in this situation like me, even after setting the API key properly.